### PR TITLE
release: prepare jira2py 0.5.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,13 +65,13 @@ jobs:
         run: uv sync --group dev
 
       - name: Ruff lint
-        run: uv run ruff check src tests examples
+        run: uv run ruff check src tests examples scripts
 
       - name: Ruff format
-        run: uv run ruff format --check src tests examples
+        run: uv run ruff format --check src tests examples scripts
 
       - name: Type check
-        run: uv run ty check src/ tests/ examples/
+        run: uv run ty check src/ tests/ examples/ scripts/
 
       - name: Tests
         run: uv run pytest tests/ -v

--- a/.gitignore
+++ b/.gitignore
@@ -160,11 +160,7 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
-.aider*
-
 .ruff*
-
-agent_*.md
 
 # Generated docs artifacts
 docs/api-reference.json

--- a/Makefile
+++ b/Makefile
@@ -1,32 +1,40 @@
-.PHONY: lint format type-check check clean help test test-cov test-verbose build release docs docs-serve
+.PHONY: lint format type-check check check-ci clean help test test-cov test-verbose build bump-version version-current release-prep release push-release-tag docs docs-serve ensure-main-clean
+
+PART ?= patch
+VERSION_INPUT := $(or $(VERSION),$(v))
 
 help:
 	@echo "Available targets:"
-	@echo "  lint        - Run ruff linting with auto-fix"
-	@echo "  format      - Run ruff formatting"
-	@echo "  type-check  - Run ty type checking"
-	@echo "  test        - Run pytest test suite"
-	@echo "  test-cov    - Run pytest with coverage report"
-	@echo "  test-verbose- Run pytest with verbose output"
-	@echo "  check       - Run all checks (lint, format, type-check, test)"
-	@echo "  build       - Build sdist and wheel"
-	@echo "  release     - Create a release (usage: make release v=0.5.0)"
-	@echo "  docs        - Build documentation"
-	@echo "  docs-serve  - Serve documentation locally with live reload"
-	@echo "  clean       - Clean Python cache files"
-	@echo "  help        - Show this help message"
+	@echo "  lint            - Run ruff linting with auto-fix"
+	@echo "  format          - Run ruff formatting"
+	@echo "  type-check      - Run ty type checking"
+	@echo "  test            - Run pytest test suite"
+	@echo "  test-cov        - Run pytest with coverage report"
+	@echo "  test-verbose    - Run pytest with verbose output"
+	@echo "  check           - Run mutating local checks (lint, format, type-check, test)"
+	@echo "  check-ci        - Run non-mutating CI-style checks"
+	@echo "  build           - Build sdist and wheel"
+	@echo "  bump-version    - Bump version (default patch) or set VERSION=0.5.0 / v=0.5.0"
+	@echo "  version-current - Print the current project version"
+	@echo "  release-prep    - Bump version and run non-mutating checks"
+	@echo "  release         - Create a local annotated release tag from a clean main branch"
+	@echo "  push-release-tag- Push the current release tag only"
+	@echo "  docs            - Build documentation"
+	@echo "  docs-serve      - Serve documentation locally with live reload"
+	@echo "  clean           - Clean Python cache files"
+	@echo "  help            - Show this help message"
 
 # Run ruff linting with auto-fix
 lint:
-	uv run ruff check --fix src tests examples
+	uv run ruff check --fix src tests examples scripts
 
 # Run ruff formatting
 format:
-	uv run ruff format src tests examples
+	uv run ruff format src tests examples scripts
 
 # Run ty type checking
 type-check:
-	uv run ty check src/ tests/ examples/
+	uv run ty check src/ tests/ examples/ scripts/
 
 # Run pytest test suite
 test:
@@ -43,27 +51,60 @@ test-verbose:
 # Run all checks
 check: lint format type-check test
 
+# Run non-mutating CI-style checks
+check-ci:
+	uv run --frozen ruff check src tests examples scripts
+	uv run --frozen ruff format --check src tests examples scripts
+	uv run --frozen ty check src/ tests/ examples/ scripts/
+	uv run --frozen pytest tests/ -v
+
 # Build sdist and wheel
 build: clean
 	uv build
 
-# Create a release: make release v=0.5.0
-release:
-ifndef v
-	$(error Usage: make release v=0.5.0)
-endif
-	@echo "Releasing v$(v)..."
-	@# Update version in pyproject.toml
-	perl -i -pe 's/^version = ".*"/version = "$(v)"/' pyproject.toml
-	@# Run all checks before releasing
-	$(MAKE) check
-	@# Commit, tag, and push
-	git add pyproject.toml
-	git diff --cached --quiet && echo "Version already set to $(v), skipping commit." || git commit -m "release: v$(v)"
-	git tag -f "v$(v)"
-	git push origin main
-	git push origin "v$(v)" --force
-	@echo "Release v$(v) pushed. CI will build, create GitHub Release, and publish to PyPI."
+# Print the current project version
+version-current:
+	@uv run --frozen python scripts/bump_version.py --current
+
+# Bump the project version
+bump-version:
+	@args="--part $(PART)"; \
+	if [ -n "$(VERSION_INPUT)" ]; then args="--version $(VERSION_INPUT)"; fi; \
+	new_version="$$(uv run --frozen python scripts/bump_version.py $$args)" || exit $$?; \
+	echo "Version set to $$new_version"
+
+# Prepare a release on dev before opening a PR to main
+release-prep:
+	$(MAKE) bump-version VERSION="$(VERSION_INPUT)" PART="$(PART)"
+	$(MAKE) check-ci
+	@echo "Release prep complete for v$$(uv run --frozen python scripts/bump_version.py --current)"
+	@echo "Review the diff, update docs/changelog.md if needed, and open a PR from dev to main."
+
+# Require a clean main branch before tagging a release
+ensure-main-clean:
+	@test "$$(git branch --show-current)" = "main" || (echo "Release tagging must be run from the main branch." && exit 1)
+	@git diff --quiet || (echo "Working tree must be clean before tagging a release." && exit 1)
+	@git diff --cached --quiet || (echo "Index must be clean before tagging a release." && exit 1)
+
+# Create a local release tag without pushing main or force-updating tags
+release: ensure-main-clean
+	@version="$$(uv run --frozen python scripts/bump_version.py --current)"; \
+	if git rev-parse -q --verify "refs/tags/v$$version" >/dev/null; then \
+		echo "Local tag v$$version already exists."; \
+		exit 1; \
+	fi; \
+	if git ls-remote --exit-code --tags origin "refs/tags/v$$version" >/dev/null 2>&1; then \
+		echo "Remote tag v$$version already exists."; \
+		exit 1; \
+	fi; \
+	git tag -a "v$$version" -m "Release v$$version"; \
+	echo "Created local tag v$$version"
+
+# Push the release tag only to trigger publishing
+push-release-tag:
+	@version="$$(uv run --frozen python scripts/bump_version.py --current)"; \
+	git rev-parse -q --verify "refs/tags/v$$version" >/dev/null || { echo "Local tag v$$version does not exist."; exit 1; }; \
+	git push origin "refs/tags/v$$version"
 
 # Build documentation
 docs:

--- a/Makefile
+++ b/Makefile
@@ -59,9 +59,9 @@ endif
 	$(MAKE) check
 	@# Commit, tag, and push
 	git add pyproject.toml
-	git commit -m "release: v$(v)"
-	git tag "v$(v)"
-	git push origin main --tags
+	git diff --cached --quiet && echo "Version already set to $(v), skipping commit." || git commit -m "release: v$(v)"
+	git tag -f "v$(v)"
+	git push origin main "v$(v)" --force
 	@echo "Release v$(v) pushed. CI will build, create GitHub Release, and publish to PyPI."
 
 # Build documentation

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,8 @@ endif
 	git add pyproject.toml
 	git diff --cached --quiet && echo "Version already set to $(v), skipping commit." || git commit -m "release: v$(v)"
 	git tag -f "v$(v)"
-	git push origin main "v$(v)" --force
+	git push origin main
+	git push origin "v$(v)" --force
 	@echo "Release v$(v) pushed. CI will build, create GitHub Release, and publish to PyPI."
 
 # Build documentation

--- a/docs/api/exceptions.md
+++ b/docs/api/exceptions.md
@@ -41,7 +41,7 @@ Base exception for all jira2py errors.
 
 Raised when authentication or authorization fails (HTTP 401, 403).
 
-Inherits from [`JiraAPIError`](#jiraapierror), so it is also caught by `except JiraAPIError` and carries the same `status_code`, `response`, and `error_messages` metadata when available.
+Inherits from [`JiraAPIError`](#jiraapierror), so it is also caught by `except JiraAPIError` and carries the same `status_code`, `response`, and `error_messages` metadata when available. For direct construction, `status_code` defaults to `401` and `response` defaults to `None`.
 
 ## `JiraConnectionError`
 
@@ -60,7 +60,7 @@ Raised for HTTP 4xx and 5xx responses not covered by a more specific exception.
 
 Includes `JiraAuthenticationError` and all other HTTP-error subclasses.
 
-Also inherits `message` and `response` from [`JiraError`](#jiraerror).
+Also inherits `message` and `response` from [`JiraError`](#jiraerror). `response` may be `None` when no HTTP response object is available.
 
 ## `JiraNotFoundError`
 

--- a/docs/api/exceptions.md
+++ b/docs/api/exceptions.md
@@ -20,9 +20,9 @@ For usage patterns and examples, see [Error Handling](../guide/error-handling.md
 
 ```
 JiraError
-├── JiraAuthenticationError
 ├── JiraConnectionError
 └── JiraAPIError
+    ├── JiraAuthenticationError
     ├── JiraNotFoundError
     ├── JiraRateLimitError
     └── JiraValidationError
@@ -41,7 +41,7 @@ Base exception for all jira2py errors.
 
 Raised when authentication or authorization fails (HTTP 401, 403).
 
-Inherits all attributes from [`JiraError`](#jiraerror).
+Inherits from [`JiraAPIError`](#jiraapierror), so it is also caught by `except JiraAPIError` and carries the same `status_code`, `response`, and `error_messages` metadata when available.
 
 ## `JiraConnectionError`
 
@@ -57,6 +57,8 @@ Raised for HTTP 4xx and 5xx responses not covered by a more specific exception.
 |---|---|---|
 | `status_code` | `int` | HTTP status code |
 | `error_messages` | `list[str]` | Error messages extracted from the Jira response body |
+
+Includes `JiraAuthenticationError` and all other HTTP-error subclasses.
 
 Also inherits `message` and `response` from [`JiraError`](#jiraerror).
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -38,8 +38,8 @@ jira.users             # Users — search
 
 Most methods accept two optional keyword arguments for extensibility:
 
-- **`extra_params`** — Additional query parameters merged into the request URL. Named parameters take precedence over `extra_params` if there's a key conflict.
-- **`extra_data`** — Additional fields merged into the request body. Named data fields take precedence over `extra_data` if there's a key conflict.
+- **`extra_params`** — Additional query parameters merged into the request URL. `extra_params` takes precedence over named parameters if there's a key conflict.
+- **`extra_data`** — Additional fields merged into the request body. `extra_data` takes precedence over named data fields if there's a key conflict.
 
 These allow you to use Jira REST API parameters that jira2py doesn't expose as named arguments:
 

--- a/docs/api/issue-comments.md
+++ b/docs/api/issue-comments.md
@@ -23,7 +23,7 @@ comments = jira.comments.get_comments("PROJ-123", order_by="-created")
 |---|---|---|---|
 | `issue_id` | `str` | required | Issue ID or key |
 | `start_at` | `int` | `0` | Index of the first comment to return (0-based) |
-| `max_results` | `int` | `100` | Maximum number of comments |
+| `max_results` | `int` | shared default page size (`50`) | Maximum number of comments |
 | `order_by` | `str \| None` | `None` | Sort order: `"created"`, `"-created"`, `"updated"`, or `"-updated"` |
 | `expand` | `str \| None` | `None` | Comma-separated fields to expand (e.g., `"renderedBody"`) |
 | `extra_params` | `Mapping[str, Any] \| None` | `None` | Additional query parameters |

--- a/docs/api/issue-search.md
+++ b/docs/api/issue-search.md
@@ -39,10 +39,10 @@ while results.get("nextPageToken"):
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `jql` | `str` | required | JQL query string |
-| `next_page_token` | `str \| None` | `None` | Token for fetching the next page of results |
+| `next_page_token` | `str \| None` | `None` | Token for fetching the next page of results. Omitted from the request body when `None`. |
 | `max_results` | `int` | `50` | Maximum items per page |
-| `fields` | `list[str] \| None` | `None` | Fields to return (e.g., `["summary", "status"]`). Use `["*all"]` for all. |
-| `expand` | `str \| None` | `None` | Comma-separated properties to expand |
+| `fields` | `list[str] \| None` | `None` | Fields to return (e.g., `["summary", "status"]`). Use `["*all"]` for all. Omitted from the request body when `None`. |
+| `expand` | `str \| None` | `None` | Comma-separated properties to expand. Omitted from the request body when `None`. |
 | `extra_params` | `Mapping[str, Any] \| None` | `None` | Additional query parameters |
 | `extra_data` | `Mapping[str, Any] \| None` | `None` | Additional request body data |
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,13 +2,21 @@
 
 ## Unreleased
 
-## v0.4.1
+## v0.5.0
+
+Compatibility-honest minor release for accepted caller-visible behavior changes that should not be framed as a patch-only update.
+
+### Compatibility notes
+
+- `extra_params` and `extra_data` override named query/body fields when the same keys are provided in both places.
+- `JiraAuthenticationError` subclasses `JiraAPIError`, so broad `except JiraAPIError` handlers also catch authentication/authorization failures.
+- `search.enhanced_search()` omits optional `None` values from the request body instead of sending JSON `null`.
 
 ### Documentation
 
-- Clarified that `extra_params` and `extra_data` override named query/body fields on key conflicts.
-- Documented that `JiraAuthenticationError` now subclasses `JiraAPIError` and includes API error metadata (`status_code`, `response`, and `error_messages`) when available.
-- Documented that `search.enhanced_search()` omits optional `None` values from the request body instead of sending JSON `null`.
+- Clarified the caller-visible precedence behavior for `extra_params` and `extra_data`.
+- Documented the `JiraAuthenticationError` / `JiraAPIError` hierarchy and shared API error metadata (`status_code`, `response`, and `error_messages`) when available.
+- Documented that `search.enhanced_search()` omits optional `None` values from the request body.
 
 ### Tooling
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Unreleased
+
+## v0.4.1
+
+### Documentation
+
+- Clarified that `extra_params` and `extra_data` override named query/body fields on key conflicts.
+- Documented that `JiraAuthenticationError` now subclasses `JiraAPIError` and includes API error metadata (`status_code`, `response`, and `error_messages`) when available.
+- Documented that `search.enhanced_search()` omits optional `None` values from the request body instead of sending JSON `null`.
+
+### Tooling
+
+- Added a reusable version bump helper plus safer release-prep and tag-push automation for the `dev -> PR -> main -> tag` release flow.
+
 ## v0.4.0
 
 ### Breaking Changes

--- a/docs/guide/error-handling.md
+++ b/docs/guide/error-handling.md
@@ -77,7 +77,7 @@ HTTP error exceptions add:
 | `status_code` | `int` | HTTP status code |
 | `error_messages` | `list[str]` | Error messages extracted from the Jira response body |
 
-`JiraAuthenticationError` is a subclass of `JiraAPIError`, so 401/403 failures are also caught by `except JiraAPIError` and include the same `status_code`, `response`, and `error_messages` metadata when available.
+`JiraAuthenticationError` is a subclass of `JiraAPIError`, so 401/403 failures are also caught by `except JiraAPIError` and include the same `status_code`, `response`, and `error_messages` metadata when available. When constructing one directly, `status_code` defaults to `401` and `response` defaults to `None`.
 
 ```python
 from jira2py import JiraAPIError
@@ -86,6 +86,7 @@ try:
     jira.issues.create_issue(fields={"project": {"key": "INVALID"}})
 except JiraAPIError as e:
     print(e.status_code)      # 400
+    print(e.response)         # Response | None
     print(e.error_messages)   # ["Field 'summary' is required", ...]
 ```
 

--- a/docs/guide/error-handling.md
+++ b/docs/guide/error-handling.md
@@ -6,9 +6,9 @@ All errors raised by jira2py are subclasses of `JiraError`, so you can catch eve
 
 ```
 JiraError
-├── JiraAuthenticationError        → 401, 403
 ├── JiraConnectionError            → timeouts, DNS failures, network errors
 └── JiraAPIError                   → HTTP 4xx / 5xx
+    ├── JiraAuthenticationError    → 401, 403
     ├── JiraNotFoundError          → 404
     ├── JiraRateLimitError         → 429
     └── JiraValidationError        → 400
@@ -76,6 +76,8 @@ HTTP error exceptions add:
 |---|---|---|
 | `status_code` | `int` | HTTP status code |
 | `error_messages` | `list[str]` | Error messages extracted from the Jira response body |
+
+`JiraAuthenticationError` is a subclass of `JiraAPIError`, so 401/403 failures are also caught by `except JiraAPIError` and include the same `status_code`, `response`, and `error_messages` metadata when available.
 
 ```python
 from jira2py import JiraAPIError

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jira2py"
-version = "0.4.0"
+version = "0.4.1"
 description = "The Python library to interact with Atlassian Jira REST API"
 readme = "README.md"
 authors = [{ name = "nEver1", email = "7fhhwpuuo@mozmail.com" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jira2py"
-version = "0.4.1"
+version = "0.5.0"
 description = "The Python library to interact with Atlassian Jira REST API"
 readme = "README.md"
 authors = [{ name = "nEver1", email = "7fhhwpuuo@mozmail.com" }]

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+PYPROJECT_PATH = Path(__file__).resolve().parents[1] / "pyproject.toml"
+VERSION_PATTERN = re.compile(
+    r'^(version\s*=\s*")(?P<version>\d+\.\d+\.\d+)("\s*)$', re.MULTILINE
+)
+SEMVER_PATTERN = re.compile(r"^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)$")
+
+
+def read_current_version(pyproject_path: Path) -> str:
+    data = tomllib.loads(pyproject_path.read_text())
+    return data["project"]["version"]
+
+
+def parse_version(version: str) -> tuple[int, int, int]:
+    match = SEMVER_PATTERN.fullmatch(version)
+    if match is None:
+        msg = f"Unsupported version format: {version}. Expected MAJOR.MINOR.PATCH"
+        raise ValueError(msg)
+    return (
+        int(match.group("major")),
+        int(match.group("minor")),
+        int(match.group("patch")),
+    )
+
+
+def bump_version(current_version: str, part: str) -> str:
+    major, minor, patch = parse_version(current_version)
+    if part == "major":
+        return f"{major + 1}.0.0"
+    if part == "minor":
+        return f"{major}.{minor + 1}.0"
+    return f"{major}.{minor}.{patch + 1}"
+
+
+def write_version(pyproject_path: Path, new_version: str) -> None:
+    parse_version(new_version)
+    content = pyproject_path.read_text()
+    updated_content, replacements = VERSION_PATTERN.subn(
+        rf"\g<1>{new_version}\3", content, count=1
+    )
+    if replacements != 1:
+        msg = f"Could not uniquely update version in {pyproject_path}"
+        raise RuntimeError(msg)
+    if updated_content != content:
+        pyproject_path.write_text(updated_content)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Bump or print the project version.")
+    parser.add_argument(
+        "--current", action="store_true", help="Print the current version and exit."
+    )
+    parser.add_argument("--version", help="Set an explicit version such as 0.5.0.")
+    parser.add_argument(
+        "--part",
+        choices=("patch", "minor", "major"),
+        default="patch",
+        help="Version part to bump when --version is not provided (default: patch).",
+    )
+    args = parser.parse_args()
+
+    if args.current and args.version:
+        parser.error("--current cannot be combined with --version")
+
+    current_version = read_current_version(PYPROJECT_PATH)
+
+    if args.current:
+        print(current_version)
+        return 0
+
+    try:
+        new_version = args.version or bump_version(current_version, args.part)
+        write_version(PYPROJECT_PATH, new_version)
+    except (RuntimeError, ValueError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    print(new_version)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/jira2py/api/api_base.py
+++ b/src/jira2py/api/api_base.py
@@ -4,6 +4,8 @@ from typing import Any
 
 from jira2py.client import JiraClientSync
 
+_DEFAULT_PAGE_SIZE = 50
+
 
 class ApiBase:
     """Base class for API implementations.

--- a/src/jira2py/api/attachments.py
+++ b/src/jira2py/api/attachments.py
@@ -20,7 +20,7 @@ class Attachments(ApiBase):
 
         Args:
             attachment_id: The ID of the attachment (e.g., "10000").
-            extra_params: Additional query parameters.
+            extra_params: Additional query parameters. Takes priority over named parameters.
 
         Returns:
             Attachment metadata: id, filename, size, mimeType, content URL, author, created.

--- a/src/jira2py/api/issue_comments.py
+++ b/src/jira2py/api/issue_comments.py
@@ -28,7 +28,7 @@ class IssueComments(ApiBase):
             max_results: Maximum number of comments to return.
             order_by: Order by "created", "-created", "updated", or "-updated".
             expand: Comma-separated fields to expand (e.g., "renderedBody").
-            extra_params: Additional query parameters.
+            extra_params: Additional query parameters. Takes priority over named parameters.
 
         Returns:
             Paginated comments with startAt, maxResults, total, and comments list.
@@ -65,8 +65,8 @@ class IssueComments(ApiBase):
             body: Comment body in Atlassian Document Format (ADF).
             visibility: Visibility restriction (e.g., {"type": "role", "value": "Administrators"}).
             expand: Comma-separated fields to expand (e.g., "renderedBody").
-            extra_params: Additional query parameters.
-            extra_data: Additional request body data.
+            extra_params: Additional query parameters. Takes priority over named parameters.
+            extra_data: Additional request body data. Takes priority over named data parameters.
 
         Returns:
             Created comment details including id, body, author, and created timestamp.

--- a/src/jira2py/api/issue_comments.py
+++ b/src/jira2py/api/issue_comments.py
@@ -3,7 +3,7 @@
 from collections.abc import Mapping
 from typing import Any, Literal
 
-from .api_base import ApiBase
+from .api_base import _DEFAULT_PAGE_SIZE, ApiBase
 
 
 class IssueComments(ApiBase):
@@ -13,7 +13,7 @@ class IssueComments(ApiBase):
         self,
         issue_id: str,
         start_at: int = 0,
-        max_results: int = 100,
+        max_results: int = _DEFAULT_PAGE_SIZE,
         order_by: Literal["created", "-created", "updated", "-updated"] | None = None,
         expand: str | None = None,
         extra_params: Mapping[str, Any] | None = None,

--- a/src/jira2py/api/issue_search.py
+++ b/src/jira2py/api/issue_search.py
@@ -3,7 +3,7 @@
 from collections.abc import Mapping
 from typing import Any
 
-from .api_base import ApiBase
+from .api_base import _DEFAULT_PAGE_SIZE, ApiBase
 
 
 class IssueSearch(ApiBase):
@@ -13,7 +13,7 @@ class IssueSearch(ApiBase):
         self,
         jql: str,
         next_page_token: str | None = None,
-        max_results: int = 50,
+        max_results: int = _DEFAULT_PAGE_SIZE,
         fields: list[str] | None = None,
         expand: str | None = None,
         extra_params: Mapping[str, Any] | None = None,
@@ -25,27 +25,35 @@ class IssueSearch(ApiBase):
 
         Args:
             jql: JQL query string (e.g., "project = PROJ AND status = 'In Progress'").
-            next_page_token: Token for fetching the next page of results.
+            next_page_token: Token for fetching the next page of results. Omitted from
+                the request body when ``None``.
             max_results: Maximum items per page.
             fields: Fields to return (e.g., ["summary", "status"]). Use ["*all"] for all.
-            expand: Comma-separated properties to expand.
-            extra_params: Additional query parameters.
-            extra_data: Additional request body data.
+                Omitted from the request body when ``None``.
+            expand: Comma-separated properties to expand. Omitted from the request body
+                when ``None``.
+            extra_params: Additional query parameters. Takes priority over named parameters.
+            extra_data: Additional request body data. Takes priority over named data parameters.
 
         Returns:
             Search results with issues, total, and nextPageToken.
         """
+        body: dict[str, Any] = {
+            "jql": jql,
+            "maxResults": max_results,
+        }
+        if next_page_token is not None:
+            body["nextPageToken"] = next_page_token
+        if fields is not None:
+            body["fields"] = fields
+        if expand is not None:
+            body["expand"] = expand
+
         return self._as_dict(
             self._client._request_jira(
                 method="POST",
                 context_path="search/jql",
-                data={
-                    "jql": jql,
-                    "nextPageToken": next_page_token,
-                    "maxResults": max_results,
-                    "fields": fields,
-                    "expand": expand,
-                },
+                data=body,
                 extra_params=extra_params,
                 extra_data=extra_data,
             )

--- a/src/jira2py/api/issues.py
+++ b/src/jira2py/api/issues.py
@@ -3,7 +3,7 @@
 from collections.abc import Mapping
 from typing import Any
 
-from .api_base import ApiBase
+from .api_base import _DEFAULT_PAGE_SIZE, ApiBase
 
 
 class Issues(ApiBase):
@@ -24,7 +24,7 @@ class Issues(ApiBase):
             issue_id: The ID or key of the issue (e.g., "PROJ-123").
             fields: Comma-separated list of fields to retrieve. Use "*all" for all fields.
             expand: Comma-separated list of properties to expand (e.g., "renderedFields").
-            extra_params: Additional query parameters.
+            extra_params: Additional query parameters. Takes priority over named parameters.
 
         Returns:
             Issue details including key, summary, status, and other requested fields.
@@ -42,7 +42,7 @@ class Issues(ApiBase):
         self,
         issue_id: str,
         start_at: int = 0,
-        max_results: int = 50,
+        max_results: int = _DEFAULT_PAGE_SIZE,
         extra_params: Mapping[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Get the changelogs for a Jira issue.
@@ -53,7 +53,7 @@ class Issues(ApiBase):
             issue_id: The ID or key of the issue (e.g., "PROJ-123").
             start_at: Index of the first item to return (0-based).
             max_results: Maximum number of results to return.
-            extra_params: Additional query parameters.
+            extra_params: Additional query parameters. Takes priority over named parameters.
 
         Returns:
             Paginated response dict with keys: startAt, maxResults, total, isLast,
@@ -89,8 +89,8 @@ class Issues(ApiBase):
             notify_users: Whether to send email notifications.
             return_issue: Whether to return the updated issue in the response.
             expand: Comma-separated list of properties to expand.
-            extra_params: Additional query parameters.
-            extra_data: Additional request body data.
+            extra_params: Additional query parameters. Takes priority over named parameters.
+            extra_data: Additional request body data. Takes priority over named data parameters.
 
         Returns:
             Updated issue details if return_issue is True, otherwise None.
@@ -126,7 +126,7 @@ class Issues(ApiBase):
             issue_id: The ID or key of the issue (e.g., "PROJ-123").
             override_screen_security: Override screen security.
             override_editable_flag: Override editable flag.
-            extra_params: Additional query parameters.
+            extra_params: Additional query parameters. Takes priority over named parameters.
 
         Returns:
             Edit metadata including available fields and their schemas.
@@ -147,7 +147,7 @@ class Issues(ApiBase):
         self,
         project_id_or_key: str,
         start_at: int = 0,
-        max_results: int = 50,
+        max_results: int = _DEFAULT_PAGE_SIZE,
         extra_params: Mapping[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Get issue types available for creating issues in a project.
@@ -158,7 +158,7 @@ class Issues(ApiBase):
             project_id_or_key: The project ID or key (e.g., "PROJ").
             start_at: Index of the first item to return (0-based).
             max_results: Maximum number of items to return.
-            extra_params: Additional query parameters.
+            extra_params: Additional query parameters. Takes priority over named parameters.
 
         Returns:
             Issue types available for the project.
@@ -177,7 +177,7 @@ class Issues(ApiBase):
         project_id_or_key: str,
         issue_type_id: str,
         start_at: int = 0,
-        max_results: int = 50,
+        max_results: int = _DEFAULT_PAGE_SIZE,
         extra_params: Mapping[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Get fields available when creating an issue of a specific type.
@@ -189,7 +189,7 @@ class Issues(ApiBase):
             issue_type_id: The issue type ID (e.g., "10001").
             start_at: Index of the first item to return (0-based).
             max_results: Maximum number of items to return.
-            extra_params: Additional query parameters.
+            extra_params: Additional query parameters. Takes priority over named parameters.
 
         Returns:
             Fields available for creating the issue type.
@@ -217,8 +217,8 @@ class Issues(ApiBase):
         Args:
             fields: Issue fields. Must include project, issuetype, and summary.
             update_history: Whether to add the project to browse history.
-            extra_params: Additional query parameters.
-            extra_data: Additional request body data.
+            extra_params: Additional query parameters. Takes priority over named parameters.
+            extra_data: Additional request body data. Takes priority over named data parameters.
 
         Returns:
             Created issue's id, key, and self URL.

--- a/src/jira2py/api/jira_api_sync.py
+++ b/src/jira2py/api/jira_api_sync.py
@@ -3,6 +3,7 @@
 from functools import cached_property
 
 from jira2py.client import JiraClientSync, JiraCredentials
+from jira2py.client.client_sync import _DEFAULT_MAX_RETRIES, _DEFAULT_MAX_RETRY_DELAY
 
 from .attachments import Attachments
 from .issue_comments import IssueComments
@@ -33,8 +34,8 @@ class JiraAPI:
         url: str | None = None,
         username: str | None = None,
         api_token: str | None = None,
-        max_retries: int = 4,
-        max_retry_delay: float = 30.0,
+        max_retries: int = _DEFAULT_MAX_RETRIES,
+        max_retry_delay: float = _DEFAULT_MAX_RETRY_DELAY,
     ) -> None:
         """Initialize the Jira API facade.
 
@@ -43,7 +44,9 @@ class JiraAPI:
             username: JIRA username.
             api_token: JIRA API token.
             max_retries: Maximum number of retries on 429 responses. Set to 0 to disable.
+                Mirrors the client default ``_DEFAULT_MAX_RETRIES``.
             max_retry_delay: Maximum delay in seconds between retries.
+                Mirrors the client default ``_DEFAULT_MAX_RETRY_DELAY``.
         """
         self._credentials = JiraCredentials.create(
             url=url, username=username, api_token=api_token

--- a/src/jira2py/api/projects.py
+++ b/src/jira2py/api/projects.py
@@ -3,7 +3,7 @@
 from collections.abc import Mapping
 from typing import Any
 
-from .api_base import ApiBase
+from .api_base import _DEFAULT_PAGE_SIZE, ApiBase
 
 
 class Projects(ApiBase):
@@ -12,7 +12,7 @@ class Projects(ApiBase):
     def search_projects(
         self,
         start_at: int = 0,
-        max_results: int = 50,
+        max_results: int = _DEFAULT_PAGE_SIZE,
         project_ids: list[int] | None = None,
         keys: list[str] | None = None,
         query: str | None = None,
@@ -31,7 +31,7 @@ class Projects(ApiBase):
             query: Filter by matching key or name (case insensitive).
             expand: Comma-separated properties to expand
                 (description, projectKeys, lead, issueTypes, url, insight).
-            extra_params: Additional query parameters.
+            extra_params: Additional query parameters. Takes priority over named parameters.
 
         Returns:
             Paginated results with startAt, maxResults, total, isLast, and values.

--- a/src/jira2py/api/users.py
+++ b/src/jira2py/api/users.py
@@ -3,7 +3,7 @@
 from collections.abc import Mapping
 from typing import Any
 
-from .api_base import ApiBase
+from .api_base import _DEFAULT_PAGE_SIZE, ApiBase
 
 
 class Users(ApiBase):
@@ -13,7 +13,7 @@ class Users(ApiBase):
         self,
         query: str,
         start_at: int = 0,
-        max_results: int = 50,
+        max_results: int = _DEFAULT_PAGE_SIZE,
         extra_params: Mapping[str, Any] | None = None,
     ) -> list[dict[str, Any]]:
         """Search for Jira users by name or email.
@@ -24,7 +24,7 @@ class Users(ApiBase):
             query: Search string for display name or email.
             start_at: Index of the first item to return (0-based).
             max_results: Maximum results to return (max 1000).
-            extra_params: Additional query parameters.
+            extra_params: Additional query parameters. Takes priority over named parameters.
 
         Returns:
             List of user objects with accountId, displayName, emailAddress, active.

--- a/src/jira2py/client/client_sync.py
+++ b/src/jira2py/client/client_sync.py
@@ -429,7 +429,9 @@ class JiraClientSync:
                 try:
                     client.close()
                 except Exception:
-                    logger.debug("Failed to close HTTP client during cleanup", exc_info=True)
+                    logger.debug(
+                        "Failed to close HTTP client during cleanup", exc_info=True
+                    )
             cls._class_persistent_clients.clear()
 
 

--- a/src/jira2py/client/client_sync.py
+++ b/src/jira2py/client/client_sync.py
@@ -9,7 +9,13 @@ from collections.abc import Mapping
 from typing import Any, NoReturn
 
 import httpx
-from tenacity import RetryCallState, Retrying, retry_if_exception, stop_after_attempt
+from tenacity import (
+    RetryCallState,
+    Retrying,
+    retry_if_exception,
+    stop_after_attempt,
+    wait_exponential,
+)
 
 from jira2py.exceptions import (
     JiraAPIError,
@@ -38,6 +44,11 @@ _DEFAULT_MAX_RETRIES = 4
 _DEFAULT_INITIAL_RETRY_DELAY = 5.0
 _DEFAULT_MAX_RETRY_DELAY = 30.0
 _DEFAULT_JITTER_RANGE = (0.7, 1.3)
+
+# HTTP header and status code constants
+_HEADER_RETRY_AFTER = "Retry-After"
+_HEADER_RATELIMIT_REASON = "RateLimit-Reason"
+_STATUS_RATE_LIMITED = 429
 
 
 def _create_httpx_client(credentials: JiraCredentials) -> httpx.Client:
@@ -102,6 +113,11 @@ class JiraClientSync:
         self._client_key = (
             f"{credentials.url}:{credentials.username}:{credentials.api_token}"
         )
+        self._backoff = wait_exponential(
+            multiplier=_DEFAULT_INITIAL_RETRY_DELAY,
+            min=_DEFAULT_INITIAL_RETRY_DELAY,
+            max=float("inf"),
+        )
 
     def _get_persistent_client(self) -> httpx.Client:
         """Get or create a persistent HTTP client for connection pooling.
@@ -139,20 +155,24 @@ class JiraClientSync:
             context_path: API endpoint path (without leading slash).
             params: Query parameters.
             data: Request body data.
-            extra_params: Additional query parameters (lower priority than params).
-            extra_data: Additional body data (lower priority than data).
+            extra_params: Additional query parameters. Keys in extra_params take priority
+                over named parameters and can be used to override or extend them.
+            extra_data: Additional body data. Keys in extra_data take priority over named
+                data parameters and can be used to override or extend them.
 
         Returns:
             Response data as dict, list, or None for empty responses.
         """
         # Merge parameters; strip None from query params (httpx sends None as "None")
+        # extra_params takes priority over params (later keys win in dict merge)
         merged_params = {
             k: v
-            for k, v in {**(extra_params or {}), **(params or {})}.items()
+            for k, v in {**(params or {}), **(extra_params or {})}.items()
             if v is not None
         }
         # Preserve None in body data (serialized as JSON null, needed to clear fields)
-        merged_data = {**(extra_data or {}), **(data or {})}
+        # extra_data takes priority over data (later keys win in dict merge)
+        merged_data = {**(data or {}), **(extra_data or {})}
 
         request_kwargs: dict[str, Any] = {}
         if merged_params:
@@ -183,7 +203,7 @@ class JiraClientSync:
         """Check if an error is retryable (HTTP 429 only)."""
         return (
             isinstance(error, httpx.HTTPStatusError)
-            and error.response.status_code == 429
+            and error.response.status_code == _STATUS_RATE_LIMITED
         )
 
     def _wait_for_retry(self, retry_state: RetryCallState) -> float:
@@ -198,14 +218,14 @@ class JiraClientSync:
         When the server provides a Retry-After header, jitter is applied only
         *above* the server-specified minimum (additive, 0–30%) to respect the
         minimum wait. For exponential backoff, multiplicative jitter (0.7x–1.3x)
-        is used.
+        is used. The exponential base is computed via ``tenacity.wait_exponential``.
         """
-        wait = _DEFAULT_INITIAL_RETRY_DELAY * (2 ** (retry_state.attempt_number - 1))
+        wait = self._backoff(retry_state)
         has_retry_after = False
 
         exc = retry_state.outcome.exception() if retry_state.outcome else None
         if isinstance(exc, httpx.HTTPStatusError):
-            retry_after = exc.response.headers.get("Retry-After")
+            retry_after = exc.response.headers.get(_HEADER_RETRY_AFTER)
             if retry_after:
                 with contextlib.suppress(ValueError):
                     wait = float(retry_after)
@@ -228,8 +248,8 @@ class JiraClientSync:
         retry_after = None
         reason = None
         if isinstance(exc, httpx.HTTPStatusError):
-            retry_after = exc.response.headers.get("Retry-After")
-            reason = exc.response.headers.get("RateLimit-Reason")
+            retry_after = exc.response.headers.get(_HEADER_RETRY_AFTER)
+            reason = exc.response.headers.get(_HEADER_RATELIMIT_REASON)
 
         logger.warning(
             "Rate limited by Jira (attempt %d). reason=%s, retry_after=%s",
@@ -267,7 +287,8 @@ class JiraClientSync:
         Accumulates messages from all error fields in the Jira Error Collection
         schema (``errorMessages``, ``errors``, ``message``). Jira always includes
         both ``errorMessages`` and ``errors`` in error responses, and either or
-        both may contain content.
+        both may contain content. Only JSON/encoding parse errors (ValueError,
+        UnicodeDecodeError) are suppressed; programming errors propagate.
 
         Args:
             response: httpx.Response object.
@@ -277,7 +298,7 @@ class JiraClientSync:
         """
         try:
             data = response.json()
-        except Exception:
+        except (ValueError, UnicodeDecodeError):
             return []
 
         if not isinstance(data, dict):
@@ -319,13 +340,17 @@ class JiraClientSync:
             if status_code == 401:
                 raise JiraAuthenticationError(
                     "Authentication failed. Check your credentials.",
+                    status_code=401,
                     response=response,
+                    error_messages=error_messages,
                 ) from error
 
             if status_code == 403:
                 raise JiraAuthenticationError(
                     "Access forbidden. You don't have permission to access this resource.",
+                    status_code=403,
                     response=response,
+                    error_messages=error_messages,
                 ) from error
 
             if status_code == 404:
@@ -336,8 +361,8 @@ class JiraClientSync:
                     error_messages=error_messages,
                 ) from error
 
-            if status_code == 429:
-                retry_after_header = response.headers.get("Retry-After")
+            if status_code == _STATUS_RATE_LIMITED:
+                retry_after_header = response.headers.get(_HEADER_RETRY_AFTER)
                 retry_after = None
                 if retry_after_header:
                     with contextlib.suppress(ValueError):
@@ -349,7 +374,7 @@ class JiraClientSync:
                     response=response,
                     error_messages=error_messages,
                     retry_after=retry_after,
-                    rate_limit_reason=response.headers.get("RateLimit-Reason"),
+                    rate_limit_reason=response.headers.get(_HEADER_RATELIMIT_REASON),
                     reset_at=response.headers.get("X-RateLimit-Reset"),
                 ) from error
 
@@ -401,8 +426,10 @@ class JiraClientSync:
         """Close all persistent clients and release resources."""
         with cls._clients_lock:
             for client in cls._class_persistent_clients.values():
-                with contextlib.suppress(Exception):
+                try:
                     client.close()
+                except Exception:
+                    logger.debug("Failed to close HTTP client during cleanup", exc_info=True)
             cls._class_persistent_clients.clear()
 
 

--- a/src/jira2py/client/credentials.py
+++ b/src/jira2py/client/credentials.py
@@ -2,6 +2,7 @@
 
 import os
 from dataclasses import dataclass, field
+from typing import Self
 
 
 @dataclass(frozen=True)
@@ -38,7 +39,7 @@ class JiraCredentials:
         url: str | None = None,
         username: str | None = None,
         api_token: str | None = None,
-    ) -> "JiraCredentials":
+    ) -> Self:
         """Create credentials with environment variable fallback.
 
         Args:

--- a/src/jira2py/exceptions.py
+++ b/src/jira2py/exceptions.py
@@ -57,7 +57,7 @@ class JiraAPIError(JiraError):
 
     Attributes:
         status_code: HTTP status code
-        response: Full httpx.Response object
+        response: Full httpx.Response object when available, otherwise ``None``
         error_messages: List of error messages extracted from JIRA response
 
     Example:
@@ -72,7 +72,7 @@ class JiraAPIError(JiraError):
         message: str,
         *,
         status_code: int,
-        response: httpx.Response,
+        response: httpx.Response | None,
         error_messages: list[str] | None = None,
     ):
         self.status_code = status_code
@@ -93,7 +93,7 @@ class JiraAuthenticationError(JiraAPIError):
 
     Attributes:
         status_code: HTTP status code (401 or 403).
-        response: Full httpx.Response object.
+        response: Full httpx.Response object when available, otherwise ``None``.
         error_messages: List of error messages extracted from JIRA response.
 
     Example:
@@ -107,8 +107,8 @@ class JiraAuthenticationError(JiraAPIError):
         self,
         message: str,
         *,
-        status_code: int,
-        response: httpx.Response,
+        status_code: int = 401,
+        response: httpx.Response | None = None,
         error_messages: list[str] | None = None,
     ):
         super().__init__(

--- a/src/jira2py/exceptions.py
+++ b/src/jira2py/exceptions.py
@@ -33,21 +33,6 @@ class JiraError(Exception):
         super().__init__(message)
 
 
-class JiraAuthenticationError(JiraError):
-    """Raised when authentication or authorization fails.
-
-    Typically raised for HTTP 401 (unauthorized) or 403 (forbidden) responses.
-
-    Example:
-        >>> try:
-        ...     jira.get_issue("PROJ-123")
-        ... except JiraAuthenticationError:
-        ...     print("Invalid credentials or insufficient permissions")
-    """
-
-    pass
-
-
 class JiraConnectionError(JiraError):
     """Raised when network or connection issues occur.
 
@@ -93,6 +78,45 @@ class JiraAPIError(JiraError):
         self.status_code = status_code
         self.error_messages = error_messages or []
         super().__init__(message, response=response)
+
+
+class JiraAuthenticationError(JiraAPIError):
+    """Raised when authentication or authorization fails.
+
+    Inherits from ``JiraAPIError``, so callers using ``except JiraAPIError`` will
+    also catch this exception (unlike before this change).
+
+    Typically raised for HTTP 401 (unauthorized) or 403 (forbidden) responses.
+    The ``status_code`` attribute (401 or 403) can be used to distinguish the
+    two cases. The ``error_messages`` attribute contains any additional error
+    details from the Jira response.
+
+    Attributes:
+        status_code: HTTP status code (401 or 403).
+        response: Full httpx.Response object.
+        error_messages: List of error messages extracted from JIRA response.
+
+    Example:
+        >>> try:
+        ...     jira.get_issue("PROJ-123")
+        ... except JiraAuthenticationError as e:
+        ...     print(f"Auth failed ({e.status_code}): invalid credentials or insufficient permissions")
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int,
+        response: httpx.Response,
+        error_messages: list[str] | None = None,
+    ):
+        super().__init__(
+            message,
+            status_code=status_code,
+            response=response,
+            error_messages=error_messages,
+        )
 
 
 class JiraNotFoundError(JiraAPIError):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -263,6 +263,9 @@ class TestHTTPStatusMapping:
             client._handle_error(http_error)
 
         assert error_message.lower() in str(exc_info.value).lower()
+        assert exc_info.value.status_code == status_code
+        assert exc_info.value.response is mock_response
+        assert exc_info.value.error_messages == ["Error"]
         assert exc_info.value.__cause__ is http_error
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -453,3 +453,36 @@ class TestRetryOnRateLimit:
             assert call_count == 1  # No retries for 500
         finally:
             client._class_persistent_clients.pop(client._client_key, None)
+
+
+class TestExtraParamsOverride:
+    """Tests for extra_params/extra_data merge priority."""
+
+    def test_extra_params_override_named_params(self, test_credentials):
+        """extra_params keys take priority over named params when both are supplied."""
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return httpx.Response(200, json={"key": "TEST-1"})
+
+        client = JiraClientSync(test_credentials)
+        client._class_persistent_clients[client._client_key] = httpx.Client(
+            transport=httpx.MockTransport(handler),
+            base_url=f"{test_credentials.url}/rest/api/3",
+            auth=httpx.BasicAuth(test_credentials.username, test_credentials.api_token),
+        )
+        try:
+            client._request_jira(
+                "GET",
+                "issue/TEST-1",
+                params={"fields": "summary"},
+                extra_params={"fields": "status"},
+            )
+            assert len(captured) == 1
+            # extra_params should win: fields=status not fields=summary
+            query_string = str(captured[0].url.params)
+            assert "status" in query_string
+            assert "summary" not in query_string
+        finally:
+            client._class_persistent_clients.pop(client._client_key, None)

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -87,12 +87,16 @@ class TestJiraAuthenticationError:
 
     def test_authentication_error_message(self):
         """Test that JiraAuthenticationError stores message correctly."""
-        error = JiraAuthenticationError(
-            "Invalid credentials",
-            status_code=401,
-            response=httpx.Response(401, json={}),
-        )
+        error = JiraAuthenticationError("Invalid credentials")
         assert "credentials" in str(error).lower()
+
+    def test_authentication_error_direct_construction_defaults(self):
+        """Test that JiraAuthenticationError supports message-only construction."""
+        error = JiraAuthenticationError("Invalid credentials")
+        assert error.status_code == 401
+        assert error.response is None
+        assert error.error_messages == []
+        assert str(error) == "Invalid credentials"
 
     def test_authentication_error_with_response(self):
         """Test that JiraAuthenticationError can store response."""
@@ -171,6 +175,13 @@ class TestJiraAPIError:
 
         mock_response = httpx.Response(500, json={"message": "Server error"})
         error = JiraAPIError("API error", status_code=500, response=mock_response)
+        assert error.error_messages == []
+
+    def test_api_error_allows_missing_response(self):
+        """Test that JiraAPIError accepts response=None when status is known."""
+        error = JiraAPIError("API error", status_code=500, response=None)
+        assert error.status_code == 500
+        assert error.response is None
         assert error.error_messages == []
 
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,5 +1,6 @@
 """Tests for jira2py exception hierarchy."""
 
+import httpx
 import pytest
 
 from jira2py.exceptions import (
@@ -86,14 +87,47 @@ class TestJiraAuthenticationError:
 
     def test_authentication_error_message(self):
         """Test that JiraAuthenticationError stores message correctly."""
-        error = JiraAuthenticationError("Invalid credentials")
+        error = JiraAuthenticationError(
+            "Invalid credentials",
+            status_code=401,
+            response=httpx.Response(401, json={}),
+        )
         assert "credentials" in str(error).lower()
 
     def test_authentication_error_with_response(self):
         """Test that JiraAuthenticationError can store response."""
-        mock_response = None
-        error = JiraAuthenticationError("Auth failed", response=mock_response)
-        assert error.response is None
+        mock_response = httpx.Response(401, json={})
+        error = JiraAuthenticationError(
+            "Auth failed",
+            status_code=401,
+            response=mock_response,
+        )
+        assert error.response is not None
+
+    def test_authentication_error_has_status_code(self):
+        """Test that JiraAuthenticationError exposes status_code and error_messages."""
+        error = JiraAuthenticationError(
+            "Auth failed",
+            status_code=401,
+            response=httpx.Response(401, json={}),
+        )
+        assert error.status_code == 401
+        assert error.error_messages == []
+
+    def test_authentication_error_distinguishable_401_vs_403(self):
+        """Test that 401 and 403 errors can be distinguished by status_code."""
+        err_401 = JiraAuthenticationError(
+            "Unauthorized",
+            status_code=401,
+            response=httpx.Response(401, json={}),
+        )
+        err_403 = JiraAuthenticationError(
+            "Forbidden",
+            status_code=403,
+            response=httpx.Response(403, json={}),
+        )
+        assert err_401.status_code == 401
+        assert err_403.status_code == 403
 
 
 class TestJiraConnectionError:

--- a/tests/test_issue_comments.py
+++ b/tests/test_issue_comments.py
@@ -2,11 +2,12 @@
 
 import httpx
 
+from jira2py.api.api_base import _DEFAULT_PAGE_SIZE
 from jira2py.api.issue_comments import IssueComments
 
 SAMPLE_COMMENTS = {
     "startAt": 0,
-    "maxResults": 100,
+    "maxResults": _DEFAULT_PAGE_SIZE,
     "total": 1,
     "comments": [
         {"id": "10000", "body": {"type": "doc", "content": []}},
@@ -42,6 +43,16 @@ class TestIssueComments:
         result = api.get_comments("TEST-1", order_by="-created")
 
         assert result["total"] == 1
+
+    def test_get_comments_uses_shared_default_page_size(self, make_client):
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.params["maxResults"] == str(_DEFAULT_PAGE_SIZE)
+            return httpx.Response(200, json=SAMPLE_COMMENTS)
+
+        api = IssueComments(make_client(handler))
+        result = api.get_comments("TEST-1")
+
+        assert result["maxResults"] == _DEFAULT_PAGE_SIZE
 
     def test_add_comment(self, make_client):
         def handler(request: httpx.Request) -> httpx.Response:

--- a/tests/test_issue_search.py
+++ b/tests/test_issue_search.py
@@ -37,3 +37,23 @@ class TestIssueSearch:
         )
 
         assert result["total"] == 1
+
+    def test_enhanced_search_omits_none_fields(self, make_client):
+        """Optional fields absent from the request body when not supplied."""
+        captured: list[bytes] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request.content)
+            return httpx.Response(200, json=SAMPLE_SEARCH)
+
+        api = IssueSearch(make_client(handler))
+        api.enhanced_search("project = TEST")
+
+        import json
+
+        body = json.loads(captured[0])
+        assert "nextPageToken" not in body
+        assert "fields" not in body
+        assert "expand" not in body
+        assert body["jql"] == "project = TEST"
+        assert body["maxResults"] == 50

--- a/uv.lock
+++ b/uv.lock
@@ -376,7 +376,7 @@ wheels = [
 
 [[package]]
 name = "jira2py"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx", extra = ["http2"] },


### PR DESCRIPTION
## Summary
Prepare the `jira2py` `0.5.0` release with compatibility-honest framing for the caller-visible behavior already on `dev`.

## Release target
- `0.5.0`

## Compatibility notes
- `extra_params` / `extra_data` override named fields when keys overlap
- `JiraAuthenticationError` subclasses `JiraAPIError`
- `enhanced_search()` omits optional `None` fields from request payloads

## Release / publishing workflow
- merge this PR to `main`
- tag merged `main` as `v0.5.0`
- publish via PyPI Trusted Publishing

## Validation
- [x] `make lint`
- [x] `make format`
- [x] `make type-check`
- [x] `make test` (`85 passed`)
- [x] `make build`
- [x] `make docs` (passed with existing `llms.txt` / `llms-full.txt` warnings)
