### PR TITLE
feat: add issue worklogs API

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ jira = JiraAPI()  # no arguments needed
 | **Issues**         | Get, create, edit issues; changelogs; edit metadata; create metadata |
 | **Issue Search**   | JQL search with pagination                                           |
 | **Issue Comments** | List and add comments                                                |
+| **Issue Worklogs** | Retrieve issue worklogs as raw Jira pages                            |
 | **Issue Fields**   | List system and custom fields                                        |
 | **Issue Links**    | List link types, create and delete links                             |
 | **Projects**       | Search and list projects                                             |

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -10,6 +10,7 @@ jira = JiraAPI()
 jira.issues            # Issues — get, create, edit, metadata
 jira.search            # Issue Search — JQL queries
 jira.comments          # Issue Comments — list, add
+jira.worklogs          # Issue Worklogs — list worklogs for an issue
 jira.fields            # Issue Fields — list system and custom fields
 jira.issue_links       # Issue Links — link types, create, delete
 jira.projects          # Projects — search and list
@@ -25,6 +26,7 @@ jira.users             # Users — search
 | [Issues](issues.md) | `jira.issues` | Create, read, and update issues; changelogs and create/edit metadata |
 | [Issue Search](issue-search.md) | `jira.search` | Search issues with JQL |
 | [Issue Comments](issue-comments.md) | `jira.comments` | List and add comments |
+| [Issue Worklogs](issue-worklogs.md) | `jira.worklogs` | Retrieve issue worklogs as raw Jira pages |
 | [Issue Fields](issue-fields.md) | `jira.fields` | List system and custom fields |
 | [Issue Links](issue-links.md) | `jira.issue_links` | List link types, create and delete links |
 | [Projects](projects.md) | `jira.projects` | Search and list projects |

--- a/docs/api/issue-worklogs.md
+++ b/docs/api/issue-worklogs.md
@@ -1,0 +1,41 @@
+# Issue Worklogs
+
+Accessed via `jira.worklogs`. Retrieve the raw Jira worklog page for a single issue.
+
+!!! note
+    This is a low-level wrapper around Jira's issue worklogs endpoint. It returns the raw Jira response page and does not auto-paginate, aggregate, or build reports.
+
+## `get_worklogs`
+
+Get worklogs for an issue.
+
+```python
+worklogs = jira.worklogs.get_worklogs("PROJ-123")
+print(f"Total worklogs: {worklogs['total']}")
+
+for worklog in worklogs["worklogs"]:
+    print(worklog["author"]["displayName"], worklog["timeSpentSeconds"])
+```
+
+```python
+# Pass Jira worklog query params through extra_params
+worklogs = jira.worklogs.get_worklogs(
+    "PROJ-123",
+    extra_params={
+        "startedAfter": 1719273600000,
+        "startedBefore": 1719360000000,
+        "expand": "properties",
+    },
+)
+```
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `issue_id` | `str` | required | Issue ID or key |
+| `start_at` | `int` | `0` | Index of the first worklog to return (0-based) |
+| `max_results` | `int` | `50` | Maximum number of worklogs to return |
+| `extra_params` | `Mapping[str, Any] \| None` | `None` | Additional query parameters such as `startedAfter`, `startedBefore`, and `expand` |
+
+**Returns:** `dict[str, Any]` — paginated response with `startAt`, `maxResults`, `total`, and `worklogs`.
+
+:link: [Jira REST API — Get issue worklogs](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-worklogs/#api-rest-api-3-issue-issueidorkey-worklog-get)

--- a/docs/api/jira-api.md
+++ b/docs/api/jira-api.md
@@ -33,6 +33,7 @@ See [Configuration](../guide/configuration.md) for credential resolution and [Ra
 | `issues` | [`Issues`](issues.md) | Issue operations |
 | `search` | [`IssueSearch`](issue-search.md) | JQL search |
 | `comments` | [`IssueComments`](issue-comments.md) | Issue comments |
+| `worklogs` | [`IssueWorklogs`](issue-worklogs.md) | Issue worklogs |
 | `fields` | [`IssueFields`](issue-fields.md) | System and custom fields |
 | `issue_links` | [`IssueLinks`](issue-links.md) | Issue link operations |
 | `projects` | [`Projects`](projects.md) | Project search |

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,6 +42,7 @@ print(issue["fields"]["summary"])
 | **Issues**         | Get, create, edit issues; changelogs; edit metadata; create metadata |
 | **Issue Search**   | JQL search with pagination                                           |
 | **Issue Comments** | List and add comments                                                |
+| **Issue Worklogs** | Retrieve issue worklogs as raw Jira pages                            |
 | **Issue Fields**   | List system and custom fields                                        |
 | **Issue Links**    | List link types, create and delete links                             |
 | **Projects**       | Search and list projects                                             |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,6 +92,7 @@ nav:
       - Issues: api/issues.md
       - Issue Search: api/issue-search.md
       - Issue Comments: api/issue-comments.md
+      - Issue Worklogs: api/issue-worklogs.md
       - Issue Fields: api/issue-fields.md
       - Issue Links: api/issue-links.md
       - Projects: api/projects.md

--- a/src/jira2py/api/issue_worklogs.py
+++ b/src/jira2py/api/issue_worklogs.py
@@ -1,0 +1,42 @@
+"""Issue Worklogs API implementation."""
+
+from collections.abc import Mapping
+from typing import Any
+
+from .api_base import _DEFAULT_PAGE_SIZE, ApiBase
+
+
+class IssueWorklogs(ApiBase):
+    """Issue Worklogs API — read worklogs on issues."""
+
+    def get_worklogs(
+        self,
+        issue_id: str,
+        start_at: int = 0,
+        max_results: int = _DEFAULT_PAGE_SIZE,
+        extra_params: Mapping[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Get worklogs for an issue.
+
+        https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-worklogs/#api-rest-api-3-issue-issueidorkey-worklog-get
+
+        Args:
+            issue_id: The ID or key of the issue (e.g., "PROJ-123").
+            start_at: Index of the first worklog to return (0-based).
+            max_results: Maximum number of worklogs to return.
+            extra_params: Additional query parameters. Takes priority over named
+                parameters. Useful for Jira worklog parameters such as
+                ``startedAfter``, ``startedBefore``, and ``expand``.
+
+        Returns:
+            Paginated worklogs with ``startAt``, ``maxResults``, ``total``, and
+            ``worklogs``.
+        """
+        return self._as_dict(
+            self._client._request_jira(
+                method="GET",
+                context_path=f"issue/{issue_id}/worklog",
+                params={"startAt": start_at, "maxResults": max_results},
+                extra_params=extra_params,
+            )
+        )

--- a/src/jira2py/api/jira_api_sync.py
+++ b/src/jira2py/api/jira_api_sync.py
@@ -10,6 +10,7 @@ from .issue_comments import IssueComments
 from .issue_fields import IssueFields
 from .issue_links import IssueLinks
 from .issue_search import IssueSearch
+from .issue_worklogs import IssueWorklogs
 from .issues import Issues
 from .projects import Projects
 from .users import Users
@@ -81,6 +82,11 @@ class JiraAPI:
     def comments(self) -> IssueComments:
         """Get comments client."""
         return IssueComments(self._client)
+
+    @cached_property
+    def worklogs(self) -> IssueWorklogs:
+        """Get worklogs client."""
+        return IssueWorklogs(self._client)
 
     @cached_property
     def projects(self) -> Projects:

--- a/tests/test_issue_worklogs.py
+++ b/tests/test_issue_worklogs.py
@@ -1,0 +1,92 @@
+"""Tests for Issue Worklogs API."""
+
+import httpx
+import pytest
+
+from jira2py import JiraAPI
+from jira2py.api.api_base import _DEFAULT_PAGE_SIZE
+from jira2py.api.issue_worklogs import IssueWorklogs
+
+SAMPLE_WORKLOGS = {
+    "startAt": 0,
+    "maxResults": _DEFAULT_PAGE_SIZE,
+    "total": 1,
+    "worklogs": [
+        {
+            "id": "10000",
+            "issueId": "10001",
+            "started": "2026-06-25T09:00:00.000+0000",
+            "timeSpentSeconds": 3600,
+            "author": {"accountId": "user-1", "displayName": "Test User"},
+        }
+    ],
+}
+
+
+class TestIssueWorklogs:
+    """Tests for Issue Worklogs API."""
+
+    def test_get_worklogs_returns_raw_response_and_path(self, make_client):
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == "/rest/api/3/issue/TEST-1/worklog"
+            assert request.url.params["startAt"] == "0"
+            assert request.url.params["maxResults"] == str(_DEFAULT_PAGE_SIZE)
+            return httpx.Response(200, json=SAMPLE_WORKLOGS)
+
+        api = IssueWorklogs(make_client(handler))
+        result = api.get_worklogs("TEST-1")
+
+        assert result == SAMPLE_WORKLOGS
+
+    def test_get_worklogs_allows_extra_params_and_overrides_named_params(
+        self, make_client
+    ):
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.params["startAt"] == "3"
+            assert request.url.params["maxResults"] == "7"
+            assert request.url.params["startedAfter"] == "1719273600000"
+            assert request.url.params["startedBefore"] == "1719360000000"
+            assert request.url.params["expand"] == "properties"
+            return httpx.Response(200, json=SAMPLE_WORKLOGS)
+
+        api = IssueWorklogs(make_client(handler))
+        result = api.get_worklogs(
+            "TEST-1",
+            start_at=10,
+            max_results=25,
+            extra_params={
+                "startAt": 3,
+                "maxResults": 7,
+                "startedAfter": 1719273600000,
+                "startedBefore": 1719360000000,
+                "expand": "properties",
+            },
+        )
+
+        assert result["worklogs"][0]["id"] == "10000"
+
+    def test_get_worklogs_raises_type_error_for_non_dict_response(self, make_client):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=[{"id": "10000"}])
+
+        api = IssueWorklogs(make_client(handler))
+
+        with pytest.raises(TypeError, match="Expected dict response"):
+            api.get_worklogs("TEST-1")
+
+
+class TestJiraAPIWorklogsFacade:
+    """Tests for JiraAPI worklogs facade."""
+
+    def test_worklogs_property_is_cached(self):
+        jira = JiraAPI(
+            url="https://test.atlassian.net",
+            username="test@example.com",
+            api_token="test-token",
+        )
+
+        first = jira.worklogs
+        second = jira.worklogs
+
+        assert isinstance(first, IssueWorklogs)
+        assert first is second


### PR DESCRIPTION
## Summary
- add a low-level `IssueWorklogs` API wrapper for `issue/{issue_id}/worklog`
- expose the wrapper via `JiraAPI.worklogs`
- add tests and API/docs navigation updates for raw worklog retrieval

## Scope
- low-level wrapper only; no report or aggregation logic
- documents `extra_params` usage for Jira worklog query params

## Validation
- `make check-ci` ✅ (ruff check, ruff format --check, ty check, pytest)
- `git diff --cached --check` ✅

## Notes
- `make check` exists but is mutating (`lint` + `format`), so `make check-ci` was used for non-mutating PR validation
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/en-ver/jira2py/pull/15" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->