### PR TITLE
chore: release 0.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jira2py"
-version = "0.5.0"
+version = "0.6.0"
 description = "The Python library to interact with Atlassian Jira REST API"
 readme = "README.md"
 authors = [{ name = "nEver1", email = "7fhhwpuuo@mozmail.com" }]

--- a/uv.lock
+++ b/uv.lock
@@ -376,7 +376,7 @@ wheels = [
 
 [[package]]
 name = "jira2py"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx", extra = ["http2"] },


### PR DESCRIPTION
## Summary
- bump jira2py version from `0.5.0` to `0.6.0`
- update `uv.lock` to match the package version bump
- prepare publishing after the issue worklogs feature PR merged to `main`

## Validation
- `make version-current`
- `git diff --cached --check`

## Notes
- this PR is the release-prep step required before creating tag `v0.6.0`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/en-ver/jira2py/pull/16" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->