### PR TITLE
chore: release 0.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jira2py"
-version = "0.6.0"
+version = "0.7.0"
 description = "The Python library to interact with Atlassian Jira REST API"
 readme = "README.md"
 authors = [{ name = "nEver1", email = "7fhhwpuuo@mozmail.com" }]

--- a/uv.lock
+++ b/uv.lock
@@ -388,7 +388,7 @@ wheels = [
 
 [[package]]
 name = "jira2py"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx", extra = ["http2"] },


### PR DESCRIPTION
Version bump `0.6.0 -> 0.7.0`

Changed files:
- `pyproject.toml`
- `uv.lock`

Validation:
- `make check-ci` passed

Tag status:
- `v0.7.0` has not been created yet and will be created only after merge to publish.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/en-ver/jira2py/pull/18" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->