### PR TITLE
Release jira2py 0.8.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jira2py"
-version = "0.7.0"
+version = "0.8.0"
 description = "The Python library to interact with Atlassian Jira REST API"
 readme = "README.md"
 authors = [{ name = "nEver1", email = "7fhhwpuuo@mozmail.com" }]

--- a/uv.lock
+++ b/uv.lock
@@ -388,7 +388,7 @@ wheels = [
 
 [[package]]
 name = "jira2py"
-version = "0.7.0"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx", extra = ["http2"] },


### PR DESCRIPTION
## Summary
- release-prep only: bump jira2py version from 0.7.0 to 0.8.0
- narrow diff limited to `pyproject.toml` and `uv.lock`
- no merge/tag/publish actions performed in this PR

## Validation
- `make check-ci` passed
- version/lock/diff checks passed
- no local path dependency introduced
- root editable lock entry is pre-existing uv self-package metadata (`source = { editable = "." }` for `jira2py`)

## Diff scope
- `pyproject.toml`: version `0.7.0` -> `0.8.0`
- `uv.lock`: root package version `0.7.0` -> `0.8.0`

## Notes
- validated on commit `1a5386c0fbbb91baf5966678159849d478bc0e41`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/en-ver/jira2py/pull/20" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->