### PR TITLE
Normalize pytest invocation in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,15 +38,15 @@ type-check:
 
 # Run pytest test suite
 test:
-	uv run pytest tests/ -v
+	uv run python -m pytest tests/ -v
 
 # Run pytest with coverage report
 test-cov:
-	uv run pytest tests/ --cov=src/jira2py --cov-report=html --cov-report=term
+	uv run python -m pytest tests/ --cov=src/jira2py --cov-report=html --cov-report=term
 
 # Run pytest with verbose output
 test-verbose:
-	uv run pytest tests/ -vv
+	uv run python -m pytest tests/ -vv
 
 # Run all checks
 check: lint format type-check test
@@ -56,7 +56,7 @@ check-ci:
 	uv run --frozen ruff check src tests examples scripts
 	uv run --frozen ruff format --check src tests examples scripts
 	uv run --frozen ty check src/ tests/ examples/ scripts/
-	uv run --frozen pytest tests/ -v
+	uv run --frozen python -m pytest tests/ -v
 
 # Build sdist and wheel
 build: clean


### PR DESCRIPTION
## Scope
- Change Makefile pytest console-script invocations to `python -m pytest` through the uv-managed Python environment.

## Validation Evidence
- `make test` passed on exact commit `e77e1ade397e9fbf6264783078e3aff37329dd7d`.
- `make check` passed on exact commit `e77e1ade397e9fbf6264783078e3aff37329dd7d`.

## Notes
- No Jira behavior or live E2E validation was performed because this is a local tooling command-surface only change.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/en-ver/jira2py/pull/21" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->